### PR TITLE
fixed markerType when changing chartType

### DIFF
--- a/packages/adaptableblotter/App_Scripts/View/Chart/ChartDisplayPopup.tsx
+++ b/packages/adaptableblotter/App_Scripts/View/Chart/ChartDisplayPopup.tsx
@@ -1018,15 +1018,13 @@ class ChartDisplayPopupComponent extends React.Component<ChartDisplayPopupProps,
         let e = event.target as HTMLInputElement;
         let chartProps: IChartProperties = this.state.ChartProperties;
         chartProps.ChartType = e.value as ChartType;
-        chartProps.MarkerType = ChartUIHelper.getMarkerFor(chartProps.ChartType, chartProps.MarkerType);
         this.updateChartProperties(chartProps);
     }
 
     onMarkerTypeChange(event: React.FormEvent<any>) {
         let e = event.target as HTMLInputElement;
-        let currentMarker = e.value;
         let chartProps: IChartProperties = this.state.ChartProperties;
-        chartProps.MarkerType = ChartUIHelper.getMarkerFor(chartProps.ChartType, currentMarker);
+        chartProps.MarkerType = e.value;
         this.updateChartProperties(chartProps);
     }
 

--- a/packages/adaptableblotter/App_Scripts/View/Chart/ChartUIHelper.tsx
+++ b/packages/adaptableblotter/App_Scripts/View/Chart/ChartUIHelper.tsx
@@ -128,17 +128,12 @@ export module ChartUIHelper {
     export function getMarkerFromProps(chartProps: IChartProperties): string {
       let chartType = chartProps.ChartType;
       let markerType = chartProps.MarkerType;
-      return getMarkerFor(chartType, markerType);
-    }
-
-    export function getMarkerFor(charType: ChartType, markerType: string): string {
       // resolves marker for specified chart type since some chart types should hide markers by default
       if (markerType === "Default" || markerType === "Unset") {
-        markerType = charType == ChartType.Point ? "Automatic" : "None";
+        return chartType == ChartType.Point ? "Circle" : "None";
       } else {
-        // markerType is unchanged and we show markers that the user wants
+        return markerType // return marker that the user selected
       }
-      return markerType;
     }
 
     export function getYAxisLabelsLocations(): JSX.Element[] {


### PR DESCRIPTION
this PR fixed an issue where markerType was not correctly resolved based on currently selected chartType. Also, it combines 2 functions into one function for resolving markerType.