### PR TITLE
Fixed PieChart in scenarios with large number of data points

### DIFF
--- a/packages/adaptableblotter/App_Scripts/Utilities/Services/ChartService.ts
+++ b/packages/adaptableblotter/App_Scripts/Utilities/Services/ChartService.ts
@@ -113,8 +113,6 @@ export class ChartService implements IChartService {
     }
     let hasSecondaryColumn = StringExtensions.IsNotNullOrEmpty(chartDefinition.SecondaryColumnId);
 
-  //  console.log("BuildPieChartData:  Primary Column " + hasPrimaryColumn + " Secondary Column " + hasSecondaryColumn);
-
     let valueTotal: number = 0;
 
     if (chartDefinition.VisibleRowsOnly) {
@@ -132,30 +130,85 @@ export class ChartService implements IChartService {
           this.getSingleValueTotalForRow(row, chartDefinition, dataCounter, valueTotal)
       });
     }
+    let columns: IColumn[]= this.blotter.AdaptableBlotterStore.TheStore.getState().Grid.Columns;
+    let columnType = ColumnHelper.getColumnDataTypeFromColumnId(chartDefinition.PrimaryColumnId, columns);
+    let columnIsNumeric = columnType == DataType.Number;
+    let columnName = ColumnHelper.getFriendlyNameFromColumnId(chartDefinition.PrimaryColumnId, columns);
 
- //   console.log("BuildPieChartData dataCounter " + dataCounter.keys.length);
     let dataItems: IPieChartDataItem[] = [];
-    dataCounter.forEach((value, name) => {
-      let pieChartDataItem: IPieChartDataItem = {
-        Name: name.toString(),
-        Value: Helper.RoundNumber(value, 1),
-        // calculating ratio of column value to total values of all columns and rounded to 1 decimal place
-        Ratio: Math.round(value / valueTotal * 1000) / 10
+    if (dataCounter.size <= 15 || !columnIsNumeric) {
+      // just a few values/slices so they should easily fit in pie chart with
+      dataCounter.forEach((value, name) => {
+        let sliceItem: IPieChartDataItem = {
+          Name: name.toString(),
+          Value: Helper.RoundNumber(value, 1),
+          // calculating ratio of column value to total values of all columns and rounded to 1 decimal place
+          Ratio: Math.round(value / valueTotal * 1000) / 10
+        }
+        sliceItem.ValueAndName = this.abbreviateNum(sliceItem.Value) + " - " + sliceItem.Name;
+        sliceItem.RatioAndName = sliceItem.Ratio.toFixed(0) + " - " + sliceItem.Name;
+        sliceItem.ValueAndName = StringExtensions.abbreviateString(sliceItem.ValueAndName, 50);
+        sliceItem.RatioAndName = StringExtensions.abbreviateString(sliceItem.RatioAndName, 50);
+        sliceItem.Name = StringExtensions.abbreviateString(sliceItem.Name, 50);
+        dataItems.push(sliceItem);
+      });
+    } else {
+      // too many data values/slices to fit in pie chart so we need to group them into ranges
+      let dataMinValue: number = Number.MAX_VALUE;
+      let dataMaxValue: number = Number.MIN_VALUE;
+      // getting min and max values
+      dataCounter.forEach((id, value) => {
+        dataMinValue = Math.min(value, dataMinValue);
+        dataMaxValue = Math.max(value, dataMaxValue);
+      });
+      // calculating nice/round range interval/divisions
+      let dataValueGroups = 20;
+      let dataValueRange = dataMaxValue - dataMinValue;
+
+      let dataValueMultiplier = 1;
+      if (dataValueRange < 10) {
+          dataValueMultiplier = 100; // for very small values (e.g. B/O Spread column)
       }
+      let dataRangeInterval = dataValueRange * dataValueMultiplier / dataValueGroups;
+      let dataRangeDivisions = Math.floor((dataRangeInterval / 10) + 1 ) * 10;
 
-      pieChartDataItem.ValueAndName = this.abbreviateNum(pieChartDataItem.Value) + " - " + pieChartDataItem.Name;
-      pieChartDataItem.RatioAndName = pieChartDataItem.Ratio.toFixed(0) + " - " + pieChartDataItem.Name;
+      let dataRanges = new Map<number, any>();
+      // grouping all data values into ranges by checking which range a value belongs to
+      dataCounter.forEach((id, value) => {
+          let rangeKey = Math.floor(value * dataValueMultiplier / dataRangeDivisions);
+          if (dataRanges.has(rangeKey)) {
+            let range = dataRanges.get(rangeKey);
+            range.values.push(value);;
+            dataRanges.set(rangeKey, range);
+          } else {
+            let rangeMin: any = (rangeKey / dataValueMultiplier * dataRangeDivisions);
+            let rangeMax: any = (rangeKey + 1) / dataValueMultiplier * dataRangeDivisions;
 
-      pieChartDataItem.ValueAndName = StringExtensions.abbreviateString(pieChartDataItem.ValueAndName, 50);
-      pieChartDataItem.RatioAndName = StringExtensions.abbreviateString(pieChartDataItem.RatioAndName, 50);
-      pieChartDataItem.Name = StringExtensions.abbreviateString(pieChartDataItem.Name, 50);
-
-      dataItems.push(pieChartDataItem);
-    });
-
- //   console.log("BuildPieChartData dataItems " + dataItems.length);
- //   console.log("dataItems ");
- //   console.log(dataItems);
+            let range = { min: rangeMin, max: rangeMax, values: [value]}
+            if (dataValueMultiplier > 1) {
+              range.min = rangeMin.toFixed(1);
+              range.max = rangeMax.toFixed(1);
+            }
+            dataRanges.set(rangeKey, range);
+          }
+      });
+      console.log("ChartService grouped data items into " + dataRanges.size + " ranges of " + dataRangeDivisions)
+      // finally we can generate slice items based on data ranges
+      dataRanges.forEach((range, key) => {
+        let sliceItem: IPieChartDataItem = {
+          Name: "[" + range.min + " to " + range.max + "]",
+          Value: range.values.length,
+          // calculating ratio of number of values in this range to total number of all data rows and rounded to 1 decimal place
+          Ratio: Math.round(range.values.length / dataCounter.size * 1000) / 10
+        }
+        sliceItem.ValueAndName = sliceItem.Value + " - " + sliceItem.Name;
+        sliceItem.RatioAndName = sliceItem.Ratio.toFixed(0) + " - " + sliceItem.Name;
+        sliceItem.ValueAndName = StringExtensions.abbreviateString(sliceItem.ValueAndName, 50);
+        sliceItem.RatioAndName = StringExtensions.abbreviateString(sliceItem.RatioAndName, 50);
+        sliceItem.Name = StringExtensions.abbreviateString(sliceItem.Name, 50);
+        dataItems.push(sliceItem);
+      });
+    }
 
     return dataItems;
   }

--- a/packages/adaptableblotter/App_Scripts/View/Chart/PieChart/PieChartUIHelper.tsx
+++ b/packages/adaptableblotter/App_Scripts/View/Chart/PieChart/PieChartUIHelper.tsx
@@ -7,12 +7,12 @@ import { SliceSortOption } from "../../../Utilities/ChartEnums";
 */
 export module PieChartUIHelper {
 
-  export function getbrushesEven(): string[] {
+  export function getBrushesEven(): string[] {
     return ["#7446B9", "#9FB328", "#F96232", "#2E9CA6", "#DC3F76", "#FF9800", "#3F51B5", "#439C47"];
   }
 
 
-  export function getbrushesOdd(): string[] {
+  export function getBrushesOdd(): string[] {
     return ["#7446B9", "#9FB328", "#F96232", "#2E9CA6", "#DC3F76", "#FF9800", "#3F51B5", "#439C47", "#795548"];
   }
 
@@ -25,7 +25,7 @@ export module PieChartUIHelper {
       IsChartSettingsVisible: true,
       IsGeneralMinimised: false,
       SliceSortOption: SliceSortOption.None,
-      SliceBrushes: dataSource.length % 2 == 0 ? getbrushesOdd() : getbrushesEven(),
+      SliceBrushes: dataSource.length % 2 == 0 ? getBrushesOdd() : getBrushesEven(),
     }
 
   }

--- a/packages/adaptableblotter/App_Scripts/View/PieChart/PieChartPopup.tsx
+++ b/packages/adaptableblotter/App_Scripts/View/PieChart/PieChartPopup.tsx
@@ -35,7 +35,7 @@ interface PieChartPopupState {
     PieChartDefinition: IPieChartDefinition
 
     DataSource: any;
-   
+
     OthersCategoryType: PieChartOthersCategoryType;
     OthersCategoryThreshold: number;
     ShowAsDoughnut: boolean;
@@ -70,7 +70,7 @@ class PieChartPopupComponent extends React.Component<PieChartPopupProps, PieChar
             SliceLegendMapping: "ValueAndName",
             SliceSortOption: SliceSortOption.ValueDescending,
             SliceLabelsPosition: "OutsideEnd",
-            SliceBrushes: PieChartUIHelper.getbrushesEven(),
+            SliceBrushes: PieChartUIHelper.getBrushesEven(),
         }
 
         IgrPieChartModule.register();
@@ -122,14 +122,14 @@ class PieChartPopupComponent extends React.Component<PieChartPopupProps, PieChar
         return optionElements;
     }
 
-    
-    
+
+
     hasValidDataSelection(): boolean {
         return StringExtensions.IsNotNullOrEmpty(this.state.PieChartDefinition.SecondaryColumnId) ||
             StringExtensions.IsNotNullOrEmpty(this.state.PieChartDefinition.PrimaryColumnId);
     }
 
-  
+
     render() {
         let cssClassName: string = this.props.cssClassName + "__PieChart";
         let infoBody: any[] = ["See the count for each distinct visible value in the column as pie chart.", <br />, <br />, "There is an option to view as doughnut and to set the 'Others' threshold."]
@@ -178,7 +178,7 @@ class PieChartPopupComponent extends React.Component<PieChartPopupProps, PieChar
                 //sliceClick={(s, e) => this.onSliceClick(e)}
             />}
 
-           
+
         </div>
 
         let settingsBlock = <Panel bsSize={"xs"} bsStyle={DEFAULT_BSSTYLE} header={"Settings"} style={{
@@ -198,7 +198,7 @@ class PieChartPopupComponent extends React.Component<PieChartPopupProps, PieChar
                         checked={this.state.ShowAsDoughnut} >Doughnut View</Checkbox>
                 </HelpBlock>
 
-              
+
                 <HelpBlock style={{ fontSize: 'small' }}>Others Threshold
                         {' '}
                     <AdaptablePopover cssClassName={cssClassName} headerText={"Pie Chart: Others Threshold"} bodyText={["Items with value less than or equal to the Threshold will be assigned to the “Others” category.  Choose whether this will be interpreted as a percentage or as a value."]} />
@@ -342,11 +342,11 @@ class PieChartPopupComponent extends React.Component<PieChartPopupProps, PieChar
             PieChartDefinition: pieChartDefinition,
             DataSource: dataSource,
             // making sure the first and last slice do not have the same brush
-            SliceBrushes: dataSource.length % 2 == 0 ? PieChartUIHelper.getbrushesOdd() : PieChartUIHelper.getbrushesEven()
+            SliceBrushes: dataSource.length % 2 == 0 ? PieChartUIHelper.getBrushesOdd() : PieChartUIHelper.getBrushesEven()
         });
     }
 
-   
+
 
     public onDoughnutChartRef(doughnutChart: IgrDoughnutChart) {
         this.doughnutChart = doughnutChart;
@@ -385,7 +385,7 @@ class PieChartPopupComponent extends React.Component<PieChartPopupProps, PieChar
         this.setState({ ShowAsDoughnut: e.checked} as PieChartPopupState);
     }
 
-  
+
 
     private onThresholdAsPercentChanged(event: React.FormEvent<any>) {
         let e = event.target as HTMLInputElement;

--- a/packages/adaptableblotter/dist/App_Scripts/View/Chart/PieChart/PieChartUIHelper.d.ts
+++ b/packages/adaptableblotter/dist/App_Scripts/View/Chart/PieChart/PieChartUIHelper.d.ts
@@ -2,8 +2,8 @@ import { IPieChartDefinition, IPieChartDataItem } from "../../../Utilities/Inter
 import { PieChartComponentState } from "./PieChartComponentState";
 import { SliceSortOption } from "../../../Utilities/ChartEnums";
 export declare module PieChartUIHelper {
-    function getbrushesEven(): string[];
-    function getbrushesOdd(): string[];
+    function getBrushesEven(): string[];
+    function getBrushesOdd(): string[];
     function setChartDisplayPopupState(chartDefinition: IPieChartDefinition, dataSource: IPieChartDataItem[]): PieChartComponentState;
     function setDefaultChartDisplayPopupState(): PieChartComponentState;
     function sortDataSource(sliceSortOption: SliceSortOption, oldData: IPieChartDataItem[]): IPieChartDataItem[];


### PR DESCRIPTION
- added grouping by range of values because number of data rows was increased from 50 to 5000 and 0.072 degrees (360/5000) per slice is not enough to fit and render well in pie chart:

![image](https://user-images.githubusercontent.com/11665978/55266529-da50c380-5253-11e9-8d18-04a35056d05e.png)

With this PR, numeric column with a lot of data items will be grouped in ranges:
![image](https://user-images.githubusercontent.com/11665978/55266545-ef2d5700-5253-11e9-83a9-4bfb49a2543b.png)

Non-numeric columns work as before:
![image](https://user-images.githubusercontent.com/11665978/55266553-fe140980-5253-11e9-86ba-a60a87efe8ac.png)




